### PR TITLE
Add option for radar image opacity

### DIFF
--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -89,6 +89,7 @@ class ECRadar(object):
         height=800,
         legend=True,
         timestamp=True,
+        radar_opacity=100,
     ):
         """Initialize the radar object."""
 
@@ -127,6 +128,8 @@ class ECRadar(object):
                 os.path.join(os.path.dirname(__file__), "10x20.pil")
             )
             self.timestamp = datetime.datetime.now()
+
+        self.radar_opacity = radar_opacity
 
     async def _get_basemap(self):
         """Fetch the background map image."""
@@ -177,6 +180,15 @@ class ECRadar(object):
 
         base = Image.open(BytesIO(self.base_bytes)).convert("RGBA")
         radar = Image.open(BytesIO(radar_bytes)).convert("RGBA")
+
+        # Add transparency to radar
+
+        if self.radar_opacity < 100:
+            alpha = round((self.radar_opacity / 100) * 255)
+            radar_copy = radar.copy()
+            radar_copy.putalpha(alpha)
+            radar.paste(radar_copy, radar)
+
         frame = Image.alpha_composite(base, radar)
 
         # Add legend


### PR DESCRIPTION
This lets you specify an opacity to let the basemap show through the radar layer. On really rainy or snowy days, the map gets covered and there's no context for what the radar is showing. I left the default of 100% opacity but it would be cool if the defualt was something like 75%.

This is 65% opacity.
![loop](https://user-images.githubusercontent.com/16940333/113016986-01954080-914d-11eb-8c67-58906126d35b.gif)

