### PR TITLE
modify init code around legend to allow for legend to be false

### DIFF
--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -118,8 +118,8 @@ class ECRadar(object):
 
         self.base_bytes = None
 
+        self.legend = legend
         if legend:
-            self.legend = True
             self.legend_image = None
             self.legend_position = None
 


### PR DESCRIPTION
I noticed that if legend was configured as `False`, `_combine_layers` would throw an error because `self.legend` was not set. Simple fix!

I tested it out and it seems to work fine now, but couldn't think of a good way to write some testing around this. Would you like me to add some or is this good enough for now?