### PR TITLE
Update setup.py to exclude tests package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/michaeldavie/env_canada",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*']),
     include_package_data=True,
     install_requires=[
         "aiohttp",


### PR DESCRIPTION
otherwise it would try to install a package 'tests' at top level, what is bad style and forbidden:

```
Total: 5 packages (5 new), Size of downloads: 11666 KiB

>>> Verifying ebuild manifests
>>> Emerging (1 of 5) sci-geosciences/GeographicLib-1.52::gentoo
>>> Emerging (2 of 5) media-libs/freeimage-3.18.0-r2::gentoo
>>> Installing (1 of 5) sci-geosciences/GeographicLib-1.52::gentoo
>>> Emerging (3 of 5) dev-python/geopy-2.1.0::HomeAssistantRepository
>>> Installing (3 of 5) dev-python/geopy-2.1.0::HomeAssistantRepository
>>> Installing (2 of 5) media-libs/freeimage-3.18.0-r2::gentoo
>>> Emerging (4 of 5) dev-python/imageio-2.6.1::HomeAssistantRepository
>>> Installing (4 of 5) dev-python/imageio-2.6.1::HomeAssistantRepository
>>> Emerging (5 of 5) dev-python/env-canada-0.5.14::HomeAssistantRepository
>>> Failed to emerge dev-python/env-canada-0.5.14, Log file:
>>>  '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/build.log'
>>> Jobs: 4 of 5 complete, 1 failed                 Load avg: 1.80, 0.72, 0.33
 * Package:    dev-python/env-canada-0.5.14
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   michael.davie@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking env-canada-0.5.14.tar.gz to /var/tmp/portage/dev-python/env-canada-0.5.14/work
>>> Source unpacked in /var/tmp/portage/dev-python/env-canada-0.5.14/work
>>> Preparing source in /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
Warning: 'classifiers' should be a list, got type 'tuple'
running build
running build_py
creating /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/test_ec_aqhi.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/test_ec_historical.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/test_ec_radar.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/test_ec_weather.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
copying tests/test_ec_hydro.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests
creating /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_radar.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_aqhi.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_exc.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/__init__.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_historical.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_weather.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/ec_hydro.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
running egg_info
writing env_canada.egg-info/PKG-INFO
writing dependency_links to env_canada.egg-info/dependency_links.txt
writing requirements to env_canada.egg-info/requires.txt
writing top-level names to env_canada.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'env_canada.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'env_canada.egg-info/SOURCES.txt'
copying env_canada/10x20.pbm -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
copying env_canada/10x20.pil -> /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/env-canada-0.5.14

>>> Install dev-python/env-canada-0.5.14 into /var/tmp/portage/dev-python/env-canada-0.5.14/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9
Warning: 'classifiers' should be a list, got type 'tuple'
running install
running install_lib
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/test_ec_aqhi.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/test_ec_historical.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/__init__.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/test_ec_radar.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/test_ec_weather.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/tests/test_ec_hydro.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests
creating /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_radar.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_aqhi.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_exc.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/__init__.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/10x20.pbm -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_historical.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/10x20.pil -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_weather.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
copying /var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14-python3_9/lib/env_canada/ec_hydro.py -> /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_ec_aqhi.py to test_ec_aqhi.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_ec_historical.py to test_ec_historical.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_ec_radar.py to test_ec_radar.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_ec_weather.py to test_ec_weather.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/tests/test_ec_hydro.py to test_ec_hydro.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_radar.py to ec_radar.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_aqhi.py to ec_aqhi.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_exc.py to ec_exc.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_historical.py to ec_historical.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_weather.py to ec_weather.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada/ec_hydro.py to ec_hydro.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpo6xw7vby.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpo6xw7vby.py
removing /var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpo6xw7vby.py
writing byte-compilation script '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpuqi38s2o.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpuqi38s2o.py
removing /var/tmp/portage/dev-python/env-canada-0.5.14/temp/tmpuqi38s2o.py
running install_egg_info
running egg_info
writing env_canada.egg-info/PKG-INFO
writing dependency_links to env_canada.egg-info/dependency_links.txt
writing requirements to env_canada.egg-info/requires.txt
writing top-level names to env_canada.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'env_canada.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'env_canada.egg-info/SOURCES.txt'
Copying env_canada.egg-info to /var/tmp/portage/dev-python/env-canada-0.5.14/image/_python3.9/usr/lib/python3.9/site-packages/env_canada-0.5.14-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/env-canada-0.5.14::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2816:  Called distutils-r1_src_install
 *   environment, line 1170:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  460:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2486:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2016:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2014:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  752:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1138:  Called distutils-r1_python_install
 *   environment, line 1040:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/env-canada-0.5.14::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/env-canada-0.5.14::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14'
 * S: '/var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14'

 * Messages for package dev-python/env-canada-0.5.14:

 * ERROR: dev-python/env-canada-0.5.14::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2816:  Called distutils-r1_src_install
 *   environment, line 1170:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  460:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2486:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2016:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2014:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  752:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1138:  Called distutils-r1_python_install
 *   environment, line 1040:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/env-canada-0.5.14::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/env-canada-0.5.14::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/env-canada-0.5.14/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14'
 * S: '/var/tmp/portage/dev-python/env-canada-0.5.14/work/env_canada-0.5.14'
```