### PR TITLE
Add ECHistoricalRange class to handle hourly and daily historical data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ df = pd.read_csv(ec_en_csv.station_data)
 
 ```
 
-`ECHistoricalRange` provides historical weather data for a within a specific range and handles the update by itself.
+`ECHistoricalRange` provides historical weather data within a specific range and handles the update by itself.
 
-The ECHistoricalRange object instantiated with at least a station ID and a daterange.
+The ECHistoricalRange object is instantiated with at least a station ID and a daterange.
 One could add language, and granularity (hourly, daily (default)).
 
 The data can then be used as pandas DataFrame, XML (requires pandas >=1.3.0) and csv
@@ -172,6 +172,15 @@ In this example ```ec.df``` will be:
 | … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	|
 | 2022-07-31 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 7 	| 31 	|  	| 23,5 	|  	| 14,1 	|  	| 18,8 	|  	| 0 	|  	| 0,8 	|  	|  	|  	|  	|  	| 0 	|  	|  	|  	| 23 	|  	| 31 	|  	|  	|
 | 2022-08-01 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 8 	| 1 	|  	| 23 	|  	| 15 	|  	| 19 	|  	| 0 	|  	| 1 	|  	|  	|  	|  	|  	| 0 	|  	|  	|  	| 21 	|  	| 35 	|  	|  	|
+
+
+One should note that july 1st is excluded as the time provided contains specific hours, so it yields only data after or at exactly
+the time provided.
+
+To have all the july 1st data in that case, one can provide a datarange without time: ```datetime(2022, 7, 7)``` instead
+of ```datetime(2022, 7, 1, 12, 12)```
+
+
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ hydro_coords.measurements
 
 ## Historical Weather Data
 
-`ECHistorical` provides historical daily weather data. The ECHistorical object is instantiated with a station ID, year, language, and format (one of xml or csv). Once updated asynchronously, historical weather data is contained with the `station_data` property. If `xml` is requested, `station_data` will appear in a dictionary form. If `csv` is requested, `station_data` will contain a CSV-readable buffer. For example:
+`ECHistorical` provides historical daily weather data. The ECHistorical object is instantiated with a station ID, year, language, format (one of xml or csv) and granularity (hourly, daily or monthly data). Once updated asynchronously, historical weather data is contained with the `station_data` property. If `xml` is requested, `station_data` will appear in a dictionary form. If `csv` is requested, `station_data` will contain a CSV-readable buffer. For example:
 
 ```python
 import asyncio
@@ -105,6 +105,14 @@ ec_en_xml = ECHistorical(station_id=31688, year=2020, language="english", format
 ec_fr_xml = ECHistorical(station_id=31688, year=2020, language="french", format="xml")
 ec_en_csv = ECHistorical(station_id=31688, year=2020, language="english", format="csv")
 ec_fr_csv = ECHistorical(station_id=31688, year=2020, language="french", format="csv")
+
+# timeframe argument can be passed to change the granularity
+# timeframe=1 hourly
+# timeframe=2 daily (default)
+# timeframe=3 monthly
+ec_en_xml = ECHistorical(station_id=31688, year=2020, language="english", format="xml", timeframe=1)
+ec_en_csv = ECHistorical(station_id=31688, year=2020, language="english", format="csv", timeframe=1)
+
 
 asyncio.run(ec_en_xml.update())
 asyncio.run(ec_en_csv.update())

--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -1,8 +1,12 @@
 import copy
 import csv
 from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from io import StringIO
 import logging
+import xml.etree.ElementTree as et
+import pandas as pd
+import asyncio
 
 from aiohttp import ClientSession
 from dateutil import parser, tz
@@ -125,7 +129,8 @@ async def get_historical_stations(
     end_year=datetime.today().year,
     limit=25,
     language="english",
-    timeframe=2
+    timeframe=2,
+    month=1
 ):
     """Get list of all historical stations from Environment Canada"""
     lat, lng = coordinates
@@ -212,21 +217,25 @@ class ECHistorical(object):
                 vol.Required("year"): vol.All(
                     int, vol.Range(1840, datetime.today().year)
                 ),
+                vol.Required("month"): vol.All(
+                    int, vol.Range(1, 12)
+                ),
                 vol.Required("language", default="english"): vol.In(
                     ["english", "french"]
                 ),
                 vol.Required("format", default="xml"): vol.In(["xml", "csv"]),
-                vol.Required("timeframe", default=2): vol.In([1,2,3])
+                vol.Required("timeframe", default=2): vol.In([1,2])
             }
         )
 
         kwargs = init_schema(kwargs)
 
         self.station_id = kwargs["station_id"]
+        self.timeframe = kwargs["timeframe"]
         self.year = kwargs["year"]
+        self.month = kwargs["month"]
         self.language = kwargs["language"]
         self.format = kwargs["format"]
-        self.timeframe = kwargs["timeframe"]
         self.submit = "Download+Data"
 
         self.metadata = {}
@@ -238,6 +247,7 @@ class ECHistorical(object):
         params = {
             "stationID": self.station_id,
             "Year": self.year,
+            "Month" : self.month,
             "format": self.format,
             "timeframe": self.timeframe,
             "submit": self.submit,
@@ -330,3 +340,130 @@ class ECHistorical(object):
                         )
 
                     self.station_data[str(dt)] = cur_station_data
+
+
+def flip_daterange(f):
+    def wrapper(*args, **kwargs):
+        if kwargs.get('daterange') in globals():
+            if kwargs.get('daterange')[0] > kwargs.get('daterange')[1]:
+                kwargs['daterange'] = (kwargs.get('daterange')[1], kwargs.get('daterange')[0])
+        return f(*args, **kwargs)
+    return wrapper
+
+
+class ECHistoricalRange(object):
+    """Get historical weather data from Environment Canada in the given range for the given station.
+
+        options are daily or hourly data
+
+
+        Example:
+            import pandas as pd
+            import asyncio
+            from env_canada import ECHistoricalRange, get_historical_stations
+            from datetime import datetime
+
+            coordinates = ['48.508333', '-68.467667']
+
+            stations = pd.DataFrame(asyncio.run(get_historical_stations(coordinates, start_year=2022,
+                                                            end_year=2022, radius=200, limit=100))).T
+
+            ec = ECHistorical_range(station_id=int(stations.iloc[0,2]), timeframe="daily",
+                                    daterange=(datetime(2022, 7, 1, 12, 12), datetime(2022, 8, 1, 12, 12)))
+
+            ec.get_data()
+
+            ec.xml #yield an XML formated str. For more options, use ec.to_xml(*arg, **kwargs) with pandas options
+
+            ec.csv #yield an CSV formated str. For more options, use ec.to_csv(*arg, **kwargs) with pandas options
+
+
+    """
+    @flip_daterange
+    def __init__(self, station_id,
+                 daterange=(datetime.today().date() - relativedelta(years=1, months=1, day=1), datetime.today().date()),
+                 language="english", timeframe="daily"):
+        """
+        Return a DataFrame containing the data from the date range
+        :param station_id: the ID of the station found with get_historical_stations
+        :type station_id: int
+        :param daterange: the dates between wich the data are retreive
+        :type daterange: tuple of datetime
+        :param language: language in wich the data are retreived
+        :type language: str
+        :param timeframe: selection of granularity : 'hourly', 'daily' [or 'monthly'](to be implemented)
+        :type timeframe: str
+        """
+
+        self.df = pd.DataFrame()
+
+        self.station_id = int(station_id)
+        self.startdate, self.stopdate = daterange
+        self.months = self.monthlist(daterange=daterange)
+        self.language = language
+        _tf = {"hourly" : 1, "daily" : 2, "monthly" : 3}
+        self.timeframe = _tf[timeframe]
+
+    def get_data(self):
+        """
+        Get data from creating instance of ECHistorical
+        :return: All data in the range
+        :rtype: pd.DataFrame
+        """
+        if not self.df.empty:
+            self.df = pd.DataFrame()
+
+        ec = [ECHistorical(
+            station_id=self.station_id, year=year, month=month, language=self.language, format="csv",
+            timeframe=self.timeframe) for year, month in self.months]
+
+        for data in ec:
+            asyncio.run(data.update())
+            self.df = pd.concat((self.df, pd.read_csv(data.station_data)))
+
+        self.df = self.df.set_index(self.df.filter(regex='Date/*', axis=1).columns.values[0])
+        self.df.index = pd.to_datetime(self.df.index)
+
+        #removing the dates before and after the range as the data received might exceed the range
+        self.df = self.df[self.startdate <= self.df.index]
+        self.df = self.df[self.stopdate >= self.df.index]
+
+        return self.df
+
+    @property
+    def xml(self):
+        encoding = 'utf-8-sig'
+        return self.to_xml(encoding=encoding)
+
+    def to_xml(self, *args, **kwargs):
+        if not self.df.empty:
+            return self.df.to_xml(*args, **kwargs)
+        else:
+            return self.get_data().to_xml(*args, **kwargs)
+
+    @property
+    def csv(self):
+        if self.language == "french":
+            decimal = ","
+        else:
+            decimal = '.'
+        sep = ';'
+        encoding = 'utf-8-sig'
+        return self.to_csv(sep=sep, decimal=decimal, encoding=encoding)
+
+    def to_csv(self, *args, **kwargs):
+        if not self.df.empty:
+            return self.df.to_csv(*args, **kwargs)
+        else:
+            return self.get_data().to_csv(*args, **kwargs)
+
+    @flip_daterange
+    def monthlist(self, daterange):
+        startdate, stopdate = daterange
+        total_months = lambda dt: dt.month + 12 * dt.year
+        mlist = []
+        for tot_m in range(total_months(startdate) - 1, total_months(stopdate)):
+            y, m = divmod(tot_m, 12)
+            mlist.append((y, m + 1))
+        return mlist
+

--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -356,7 +356,6 @@ class ECHistoricalRange(object):
 
         options are daily or hourly data
 
-
         Example:
             import pandas as pd
             import asyncio
@@ -368,7 +367,7 @@ class ECHistoricalRange(object):
             stations = pd.DataFrame(asyncio.run(get_historical_stations(coordinates, start_year=2022,
                                                             end_year=2022, radius=200, limit=100))).T
 
-            ec = ECHistorical_range(station_id=int(stations.iloc[0,2]), timeframe="daily",
+            ec = ECHistoricalRange(station_id=int(stations.iloc[0,2]), timeframe="hourly",
                                     daterange=(datetime(2022, 7, 1, 12, 12), datetime(2022, 8, 1, 12, 12)))
 
             ec.get_data()
@@ -376,8 +375,6 @@ class ECHistoricalRange(object):
             ec.xml #yield an XML formated str. For more options, use ec.to_xml(*arg, **kwargs) with pandas options
 
             ec.csv #yield an CSV formated str. For more options, use ec.to_csv(*arg, **kwargs) with pandas options
-
-
     """
     @flip_daterange
     def __init__(self, station_id,

--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -125,12 +125,13 @@ async def get_historical_stations(
     end_year=datetime.today().year,
     limit=25,
     language="english",
+    timeframe=2
 ):
     """Get list of all historical stations from Environment Canada"""
     lat, lng = coordinates
     params = {
         "searchType": "stnProx",
-        "timeframe": 2,
+        "timeframe": timeframe,
         "txtRadius": radius,
         "optProxType": "decimal",
         "txtLatDecDeg": lat,

--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -217,7 +217,7 @@ class ECHistorical(object):
                 vol.Required("year"): vol.All(
                     int, vol.Range(1840, datetime.today().year)
                 ),
-                vol.Required("month"): vol.All(
+                vol.Required("month", default=1): vol.All(
                     int, vol.Range(1, 12)
                 ),
                 vol.Required("language", default="english"): vol.In(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ lxml
 Pillow
 python-dateutil
 voluptuous
+pandas>=1.3.0

--- a/tests/test_ec_historical.py
+++ b/tests/test_ec_historical.py
@@ -12,10 +12,8 @@ from env_canada import ECHistorical
         {"station_id": 48370, "year": 2021, "language": "french"},
         {"station_id": 48370, "year": 2021, "format": "csv"},
         {"station_id": 48370, "year": 2021, "format": "xml"},
-        {"station_id": 48370, "year": 2021, "format": "xml", "timeframe": 1},
+        {"station_id": 48370, "year": 2021, "month": 5, "format": "xml", "timeframe": 1},
         {"station_id": 48370, "year": 2021, "format": "csv", "timeframe": 1},
-        {"station_id": 48370, "year": 2021, "format": "xml", "timeframe": 3},
-        {"station_id": 48370, "year": 2021, "format": "csv", "timeframe": 3}
     ]
 )
 def test_echistorical(init_parameters):


### PR DESCRIPTION
In order to use the hourly timeframe correctly, I created a class to handle the looping needed for that.

The timeframe option '1' or 'hourly' yielded only one month

If find it also easier to use as it gives precise daterange in DataFrame format, XML or CSV

I had to add pandas as Requirements, I hope it's fine.

It should also close the issue #63 

Regards

# Usage

`ECHistoricalRange` provides historical weather data within a specific range and handles the update by itself.

The ECHistoricalRange object is instantiated with at least a station ID and a daterange.
One could add language, and granularity (hourly, daily (default)).

The data can then be used as pandas DataFrame, XML (requires pandas >=1.3.0) and csv

For example :

```python
import pandas as pd
import asyncio
from env_canada import ECHistoricalRange, get_historical_stations
from datetime import datetime

coordinates = ['48.508333', '-68.467667']

stations = pd.DataFrame(asyncio.run(get_historical_stations(coordinates, start_year=2022,
                                                end_year=2022, radius=200, limit=100))).T

ec = ECHistoricalRange(station_id=int(stations.iloc[0,2]), timeframe="daily",
                        daterange=(datetime(2022, 7, 1, 12, 12), datetime(2022, 8, 1, 12, 12)))

ec.get_data()

#yield an XML formated str. 
# For more options, use ec.to_xml(*arg, **kwargs) with pandas options
ec.xml
 
#yield an CSV formated str.
# For more options, use ec.to_csv(*arg, **kwargs) with pandas options
ec.csv
```

In this example ```ec.df``` will be:

| Date/Time 	| Longitude (x) 	| Latitude (y) 	| Station Name 	| Climate ID 	| Year 	| Month 	| Day 	| Data Quality 	| Max Temp (Â°C) 	| Max Temp Flag 	| Min Temp (Â°C) 	| Min Temp Flag 	| Mean Temp (Â°C) 	| Mean Temp Flag 	| Heat Deg Days (Â°C) 	| Heat Deg Days Flag 	| Cool Deg Days (Â°C) 	| Cool Deg Days Flag 	| Total Rain (mm) 	| Total Rain Flag 	| Total Snow (cm) 	| Total Snow Flag 	| Total Precip (mm) 	| Total Precip Flag 	| Snow on Grnd (cm) 	| Snow on Grnd Flag 	| Dir of Max Gust (10s deg) 	| Dir of Max Gust Flag 	| Spd of Max Gust (km/h) 	| Spd of Max   Gust Flag 	|  	|
|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|
| 2022-07-02 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 7 	| 2 	|  	| 22,8 	|  	| 12,5 	|  	| 17,7 	|  	| 0,3 	|  	| 0 	|  	|  	|  	|  	|  	| 0 	|  	|  	|  	| 26 	|  	| 37 	|  	|  	|
| 2022-07-03 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 7 	| 3 	|  	| 21,7 	|  	| 10,1 	|  	| 15,9 	|  	| 2,1 	|  	| 0 	|  	|  	|  	|  	|  	| 0,4 	|  	|  	|  	| 28 	|  	| 50 	|  	|  	|
| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	| … 	|
| 2022-07-31 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 7 	| 31 	|  	| 23,5 	|  	| 14,1 	|  	| 18,8 	|  	| 0 	|  	| 0,8 	|  	|  	|  	|  	|  	| 0 	|  	|  	|  	| 23 	|  	| 31 	|  	|  	|
| 2022-08-01 	| -68,47 	| 48,51 	| POINTE-AU-PERE (INRS) 	| 7056068 	| 2022 	| 8 	| 1 	|  	| 23 	|  	| 15 	|  	| 19 	|  	| 0 	|  	| 1 	|  	|  	|  	|  	|  	| 0 	|  	|  	|  	| 21 	|  	| 35 	|  	|  	|


One should note that july 1st is excluded as the time provided contains specific hours, so it yields only data after or at exactly
the time provided.

To have all the july 1st data in that case, one can provide a datarange without time: ```datetime(2022, 7, 7)``` instead
of ```datetime(2022, 7, 1, 12, 12)```