### PR TITLE
Set non-numeric hourly forecast wind speeds to 0

### DIFF
--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -482,7 +482,7 @@ class ECWeather(object):
                     "temperature": int(f.findtext("./temperature") or 0),
                     "icon_code": f.findtext("./iconCode"),
                     "precip_probability": int(f.findtext("./lop") or "0"),
-                    "wind_speed": int(f.findtext("./wind/speed") or 0),
+                    "wind_speed": int(wind_speed_text if str(wind_speed_text).isnumeric() else 0),
                     "wind_direction": f.findtext("./wind/direction"),
                 }
             )

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -483,7 +483,7 @@ class ECWeather(object):
                     "temperature": int(f.findtext("./temperature") or 0),
                     "icon_code": f.findtext("./iconCode"),
                     "precip_probability": int(f.findtext("./lop") or "0"),
-                    "wind_speed": int(wind_speed_text if str(wind_speed_text).isnumeric() else 0),
+                    "wind_speed": int(wind_speed_text if wind_speed_text.isnumeric() else 0),
                     "wind_direction": f.findtext("./wind/direction"),
                 }
             )

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -475,6 +475,7 @@ class ECWeather(object):
 
         # Update hourly forecasts
         for f in weather_tree.findall("./hourlyForecastGroup/hourlyForecast"):
+            wind_speed_text = f.findtext("./wind/speed")
             self.hourly_forecasts.append(
                 {
                     "period": parse_timestamp(f.attrib.get("dateTimeUTC")),


### PR DESCRIPTION
This is to help address issue #83 . The XML files that are generated by the service can sometimes have a wind speed value of "Calm" or "Calme" depending on the language.

After looking at many of the available files, the only wind speed values I saw used were 5, 10, 15, 20, 25, 30, 40, and "Calm" or "Calme". I'm assuming the "Calm" value is effectively "0".