### PR TITLE
Improve radar CPU usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: install clean isort lint test
+
+clean:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -rf {} +
+	find . -name '.cache' -exec rm -rf {} +
+	find . -name '.pytest_cache' -exec rm -rf {} +
+	rm -rf build dist *.egg-info .venv
+
+install:
+	python -m venv .venv
+	pip install -e .
+	pip install pytest
+	pip install pylint
+	pip install ruff
+
+isort:
+	sh -c "isort --skip-glob=.tox ."
+
+lint:
+	pylint --msg-template='{msg_id}({symbol}):{line:3d},{column}: {obj}: {msg}' elkm1_lib
+	ruff check
+
+test:
+	pytest tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install clean isort lint test
+.PHONY: install install-core clean isort lint test
 
 clean:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -9,11 +9,17 @@ clean:
 	rm -rf build dist *.egg-info .venv
 
 install:
-	python -m venv .venv
+ifndef VIRTUAL_ENV
+	$(error Create venv (python -m venv .venv) and activate virtual env first.)
+else
 	pip install -e .
 	pip install pytest
 	pip install pylint
 	pip install ruff
+endif
+
+install-core:
+	pip install -e .
 
 isort:
 	sh -c "isort --skip-glob=.tox ."

--- a/env_canada/ec_aqhi.py
+++ b/env_canada/ec_aqhi.py
@@ -84,7 +84,6 @@ async def find_closest_region(language, lat, lon):
 
 
 class ECAirQuality(object):
-
     """Get air quality data from Environment Canada."""
 
     def __init__(self, **kwargs):
@@ -172,7 +171,7 @@ class ECAirQuality(object):
         # Fetch current measurement
         aqhi_current = await self.get_aqhi_data(url=AQHI_OBSERVATION_URL)
 
-        if aqhi_current:
+        if aqhi_current is not None:
             # Update region name
             element = aqhi_current.find("region")
             self.region_name = element.attrib[
@@ -202,7 +201,7 @@ class ECAirQuality(object):
         # Update AQHI forecasts
         aqhi_forecast = await self.get_aqhi_data(url=AQHI_FORECAST_URL)
 
-        if aqhi_forecast:
+        if aqhi_forecast is not None:
             # Update AQHI daily forecasts
             for f in aqhi_forecast.findall("./forecastGroup/forecast"):
                 for p in f.findall("./period"):
@@ -214,6 +213,6 @@ class ECAirQuality(object):
 
             # Update AQHI hourly forecasts
             for f in aqhi_forecast.findall("./hourlyForecastGroup/hourlyForecast"):
-                self.forecasts["hourly"][
-                    timestamp_to_datetime(f.attrib["UTCTime"])
-                ] = int(f.text or 0)
+                self.forecasts["hourly"][timestamp_to_datetime(f.attrib["UTCTime"])] = (
+                    int(f.text or 0)
+                )

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -5,43 +5,6 @@ from .constants import USER_AGENT
 
 CACHE_EXPIRE_TIME = timedelta(minutes=200)  # Time is tuned for 3h radar image
 
-_cache = {}
-
-
-async def cache_get(url, params, bytes=True, cache_time=CACHE_EXPIRE_TIME):
-    """Thin wrapper around ClientSession.get to cache responses."""
-
-    def _flush_cache():
-        """Flush expired cache entries."""
-
-        now = datetime.now()
-        expired = [key for key, value in _cache.items() if value[0] < now]
-        for key in expired:
-            # _cache[key] = None
-            del _cache[key]
-
-    async def get():
-        async with ClientSession(raise_for_status=True) as session:
-            response = await session.get(
-                url=url, params=params, headers={"User-Agent": USER_AGENT}
-            )
-            if bytes:
-                return await response.read()
-            return await response.text()
-
-    _flush_cache()  # Flush at start so we don't use expired entries
-
-    cache_key = (url, tuple(sorted(params.items())))
-    result = _cache.get(cache_key)
-    if not result:
-        result = (
-            datetime.now() + cache_time,
-            await get(),
-        )
-        _cache[cache_key] = result
-
-    return result[1]
-
 
 class Resource:
     _cache = {}
@@ -49,6 +12,7 @@ class Resource:
     @classmethod
     def add_to_cache(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
         cls._cache[cache_key] = (datetime.now() + cache_time, item)
+        print(f"Caching: {cache_key}")
         return item
 
     @classmethod
@@ -60,11 +24,13 @@ class Resource:
             expired = [key for key, value in cls._cache.items() if value[0] < now]
             for key in expired:
                 # cls._cache[key] = None
+                print(f"Flushing: {key}")
                 del cls._cache[key]
 
         flush_cache()  # Flush at start so we don't use expired entries
 
         result = cls._cache.get(cache_key)
+        print(f"Cache get: {cache_key} {"Found" if result else "NOT found"}")
         return result[1] if result else None
 
     @classmethod

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -7,17 +7,25 @@ class Cache:
     _cache = {}
 
     @classmethod
+    def flush(cls):
+        """Empty the cache."""
+        _cache = {}  # type: ignore
+
+    @classmethod
     def add(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
+        """Add an entry to the cache."""
+
         cls._cache[cache_key] = (datetime.now() + cache_time, item)
         return item  # Returning item useful for chaining calls
 
     @classmethod
     def get(cls, cache_key):
-        # Flush at start so we don't use expired entries
+        """Get an entry from the cache."""
+
+        # Delete expired entries at start so we don't use expired entries
         now = datetime.now()
         expired = [key for key, value in cls._cache.items() if value[0] < now]
         for key in expired:
-            # print(f"Flushing: {key}")
             del cls._cache[key]
 
         result = cls._cache.get(cache_key)

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -1,21 +1,18 @@
-from aiohttp import ClientSession
 from datetime import datetime, timedelta
-
-from .constants import USER_AGENT
 
 CACHE_EXPIRE_TIME = timedelta(minutes=200)  # Time is tuned for 3h radar image
 
 
-class Resource:
+class Cache:
     _cache = {}
 
     @classmethod
-    def add_to_cache(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
+    def add(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
         cls._cache[cache_key] = (datetime.now() + cache_time, item)
-        return item
+        return item  # Returning item useful for chaining calls
 
     @classmethod
-    def get_from_cache(cls, cache_key):
+    def get(cls, cache_key):
         # Flush at start so we don't use expired entries
         now = datetime.now()
         expired = [key for key, value in cls._cache.items() if value[0] < now]
@@ -27,13 +24,3 @@ class Resource:
         result = cls._cache.get(cache_key)
         print(f"Cache get: {cache_key} {"Found" if result else "NOT found"}")
         return result[1] if result else None
-
-    @classmethod
-    async def get(cls, url, params, bytes=True):
-        async with ClientSession(raise_for_status=True) as session:
-            response = await session.get(
-                url=url, params=params, headers={"User-Agent": USER_AGENT}
-            )
-            if bytes:
-                return await response.read()
-            return await response.text()

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -7,11 +7,6 @@ class Cache:
     _cache = {}
 
     @classmethod
-    def flush(cls):
-        """Empty the cache."""
-        _cache = {}  # type: ignore
-
-    @classmethod
     def add(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
         """Add an entry to the cache."""
 

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -43,33 +43,36 @@ async def cache_get(url, params, bytes=True, cache_time=CACHE_EXPIRE_TIME):
     return result[1]
 
 
-# class CacheClientSession(ClientSession):
-#     """Shim to cache ClientSession requests."""
-#
-#     _cache = {}
-#
-#     def _flush_cache(self):
-#         """Flush expired cache entries."""
-#
-#         now = datetime.now()
-#         expired = [key for key, value in self._cache.items() if value[0] < now]
-#         for key in expired:
-#             del self._cache[key]
-#
-#     async def get(self, url, params, cache_time=CACHE_EXPIRE_TIME):
-#         """Thin wrapper around ClientSession.get to cache responses."""
-#
-#         self._flush_cache()  # Flush at start so we don't use expired entries
-#
-#         cache_key = (url, tuple(sorted(params.items())))
-#         result = self._cache.get(cache_key)
-#         if not result:
-#             result = (
-#                 datetime.now() + cache_time,
-#                 await super().get(
-#                     url=url, params=params, headers={"User-Agent": USER_AGENT}
-#                 ),
-#             )
-#             self._cache[cache_key] = result
-#
-#         return result[1]
+class Resource:
+    _cache = {}
+
+    @classmethod
+    def add_to_cache(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
+        cls._cache[cache_key] = (datetime.now() + cache_time, item)
+        return item
+
+    @classmethod
+    def get_from_cache(cls, cache_key):
+        def flush_cache():
+            """Flush expired cache entries."""
+
+            now = datetime.now()
+            expired = [key for key, value in cls._cache.items() if value[0] < now]
+            for key in expired:
+                # cls._cache[key] = None
+                del cls._cache[key]
+
+        flush_cache()  # Flush at start so we don't use expired entries
+
+        result = cls._cache.get(cache_key)
+        return result[1] if result else None
+
+    @classmethod
+    async def get(cls, url, params, bytes=True):
+        async with ClientSession(raise_for_status=True) as session:
+            response = await session.get(
+                url=url, params=params, headers={"User-Agent": USER_AGENT}
+            )
+            if bytes:
+                return await response.read()
+            return await response.text()

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -17,10 +17,8 @@ class Cache:
         now = datetime.now()
         expired = [key for key, value in cls._cache.items() if value[0] < now]
         for key in expired:
-            # cls._cache[key] = None
-            print(f"Flushing: {key}")
+            # print(f"Flushing: {key}")
             del cls._cache[key]
 
         result = cls._cache.get(cache_key)
-        print(f"Cache get: {cache_key} {"Found" if result else "NOT found"}")
         return result[1] if result else None

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -1,13 +1,11 @@
-from datetime import datetime, timedelta
-
-CACHE_EXPIRE_TIME = timedelta(minutes=200)  # Time is tuned for 3h radar image
+from datetime import datetime
 
 
 class Cache:
     _cache = {}
 
     @classmethod
-    def add(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
+    def add(cls, cache_key, item, cache_time):
         """Add an entry to the cache."""
 
         cls._cache[cache_key] = (datetime.now() + cache_time, item)

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -12,22 +12,17 @@ class Resource:
     @classmethod
     def add_to_cache(cls, cache_key, item, cache_time=CACHE_EXPIRE_TIME):
         cls._cache[cache_key] = (datetime.now() + cache_time, item)
-        print(f"Caching: {cache_key}")
         return item
 
     @classmethod
     def get_from_cache(cls, cache_key):
-        def flush_cache():
-            """Flush expired cache entries."""
-
-            now = datetime.now()
-            expired = [key for key, value in cls._cache.items() if value[0] < now]
-            for key in expired:
-                # cls._cache[key] = None
-                print(f"Flushing: {key}")
-                del cls._cache[key]
-
-        flush_cache()  # Flush at start so we don't use expired entries
+        # Flush at start so we don't use expired entries
+        now = datetime.now()
+        expired = [key for key, value in cls._cache.items() if value[0] < now]
+        for key in expired:
+            # cls._cache[key] = None
+            print(f"Flushing: {key}")
+            del cls._cache[key]
 
         result = cls._cache.get(cache_key)
         print(f"Cache get: {cache_key} {"Found" if result else "NOT found"}")

--- a/env_canada/ec_cache.py
+++ b/env_canada/ec_cache.py
@@ -5,34 +5,71 @@ from .constants import USER_AGENT
 
 CACHE_EXPIRE_TIME = timedelta(minutes=200)  # Time is tuned for 3h radar image
 
+_cache = {}
 
-class CacheClientSession(ClientSession):
-    """Shim to cache ClientSession requests."""
 
-    _cache = {}
+async def cache_get(url, params, bytes=True, cache_time=CACHE_EXPIRE_TIME):
+    """Thin wrapper around ClientSession.get to cache responses."""
 
-    def _flush_cache(self):
+    def _flush_cache():
         """Flush expired cache entries."""
 
         now = datetime.now()
-        expired = [key for key, value in self._cache.items() if value[0] < now]
+        expired = [key for key, value in _cache.items() if value[0] < now]
         for key in expired:
-            del self._cache[key]
+            # _cache[key] = None
+            del _cache[key]
 
-    async def get(self, url, params, cache_time=CACHE_EXPIRE_TIME):
-        """Thin wrapper around ClientSession.get to cache responses."""
-
-        self._flush_cache()  # Flush at start so we don't use expired entries
-
-        cache_key = (url, tuple(sorted(params.items())))
-        result = self._cache.get(cache_key)
-        if not result:
-            result = (
-                datetime.now() + cache_time,
-                await super().get(
-                    url=url, params=params, headers={"User-Agent": USER_AGENT}
-                ),
+    async def get():
+        async with ClientSession(raise_for_status=True) as session:
+            response = await session.get(
+                url=url, params=params, headers={"User-Agent": USER_AGENT}
             )
-            self._cache[cache_key] = result
+            if bytes:
+                return await response.read()
+            return await response.text()
 
-        return result[1]
+    _flush_cache()  # Flush at start so we don't use expired entries
+
+    cache_key = (url, tuple(sorted(params.items())))
+    result = _cache.get(cache_key)
+    if not result:
+        result = (
+            datetime.now() + cache_time,
+            await get(),
+        )
+        _cache[cache_key] = result
+
+    return result[1]
+
+
+# class CacheClientSession(ClientSession):
+#     """Shim to cache ClientSession requests."""
+#
+#     _cache = {}
+#
+#     def _flush_cache(self):
+#         """Flush expired cache entries."""
+#
+#         now = datetime.now()
+#         expired = [key for key, value in self._cache.items() if value[0] < now]
+#         for key in expired:
+#             del self._cache[key]
+#
+#     async def get(self, url, params, cache_time=CACHE_EXPIRE_TIME):
+#         """Thin wrapper around ClientSession.get to cache responses."""
+#
+#         self._flush_cache()  # Flush at start so we don't use expired entries
+#
+#         cache_key = (url, tuple(sorted(params.items())))
+#         result = self._cache.get(cache_key)
+#         if not result:
+#             result = (
+#                 datetime.now() + cache_time,
+#                 await super().get(
+#                     url=url, params=params, headers={"User-Agent": USER_AGENT}
+#                 ),
+#             )
+#             self._cache[cache_key] = result
+#
+#         return result[1]

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -221,12 +221,14 @@ class ECRadar(object):
     async def _get_dimensions(self):
         """Get time range of available radar images."""
 
-        if not (capabilities_xml := Cache.get("capabilities")):
+        capabilities_cache_key = f"capabilities-{self._precip_type_actual}"
+
+        if not (capabilities_xml := Cache.get(capabilities_cache_key)):
             capabilities_params["layer"] = precip_layers[self._precip_type_actual]
             capabilities_xml = await _get_resource(
                 geomet_url, capabilities_params, bytes=False
             )
-            Cache.add("capabilities", capabilities_xml, timedelta(minutes=5))
+            Cache.add(capabilities_cache_key, capabilities_xml, timedelta(minutes=5))
 
         dimension_string = et.fromstring(capabilities_xml).find(
             dimension_xpath.format(layer=precip_layers[self._precip_type_actual]),

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -351,7 +351,7 @@ class ECRadar(object):
 
         def create_gif():
             """Assemble animated GIF."""
-            duration = 1000 / 5
+            duration = 1000 / fps
             images = [Image.open(BytesIO(img)).convert("RGBA") for img in radar_layers]
             gif = BytesIO()
             images[0].save(

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 from io import BytesIO
+from typing import cast
 
 import dateutil.parser
 import defusedxml.ElementTree as et
@@ -249,7 +250,7 @@ class ECRadar(object):
     async def _get_radar_image(self, frame_time):
         # All the synchronous PIL stuff here
         def _create_image():
-            radar_image = Image.open(BytesIO(radar_bytes)).convert("RGBA")
+            radar_image = Image.open(BytesIO(cast(bytes, radar_bytes))).convert("RGBA")
 
             map_image = None
             if base_bytes:

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -351,16 +351,18 @@ class ECRadar(object):
 
         def create_gif():
             """Assemble animated GIF."""
-            duration = 1000 / fps
-            gif_frames = [imageio.imread(f, mode="RGBA") for f in radar_layers]
-            gif_bytes = imageio.mimwrite(
-                imageio.RETURN_BYTES,
-                gif_frames,
+            duration = 1000 / 5
+            images = [Image.open(BytesIO(img)) for img in radar_layers]
+            gif = BytesIO()
+            images[0].save(
+                gif,
                 format="GIF",
+                save_all=True,
+                append_images=images[1:],
                 duration=duration,
-                subrectangles=True,
+                loop=0,
             )
-            return gif_bytes
+            return gif.getvalue()
 
         # Prime the cache - without this the tasks below each compete
         # to load map/legend at the same time.

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -226,7 +226,7 @@ class ECRadar(object):
             capabilities_xml = await _get_resource(
                 geomet_url, capabilities_params, bytes=False
             )
-            Cache.add("capabilities", capabilities_xml, cache_time=timedelta(minutes=5))
+            Cache.add("capabilities", capabilities_xml, timedelta(minutes=5))
 
         dimension_string = et.fromstring(capabilities_xml).find(
             dimension_xpath.format(layer=precip_layers[self._precip_type_actual]),
@@ -302,7 +302,10 @@ class ECRadar(object):
             img_byte_arr = BytesIO()
             frame.save(img_byte_arr, format="PNG")
 
-            return Cache.add(f"radar-{time}", img_byte_arr.getvalue())
+            # Time is tuned for 3h radar image
+            return Cache.add(
+                f"radar-{time}", img_byte_arr.getvalue(), timedelta(minutes=200)
+            )
 
         time = frame_time.strftime("%Y-%m-%dT%H:%M:00Z")
 

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -7,7 +7,6 @@ from io import BytesIO
 
 import dateutil.parser
 import defusedxml.ElementTree as et
-import imageio.v2 as imageio
 import voluptuous as vol
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientConnectorError

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -293,7 +293,7 @@ class ECRadar(object):
                     )
 
                 if self._font:
-                    timestamp = f"{timestamp_label[self.layer_key][self.language]} @ {frame_time.astimezone().strftime("%H:%M")}"
+                    timestamp = f"{timestamp_label[self.layer_key][self.language]} @ {frame_time.astimezone().strftime('%H:%M')}"
                     text_box = Image.new(
                         "RGBA", self._font.getbbox(timestamp)[2:], "white"
                     )

--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -352,7 +352,7 @@ class ECRadar(object):
         def create_gif():
             """Assemble animated GIF."""
             duration = 1000 / 5
-            images = [Image.open(BytesIO(img)) for img in radar_layers]
+            images = [Image.open(BytesIO(img)).convert("RGBA") for img in radar_layers]
             gif = BytesIO()
             images[0].save(
                 gif,

--- a/tests/test_ec_radar.py
+++ b/tests/test_ec_radar.py
@@ -48,9 +48,9 @@ def test_get_loop(test_radar):
 
 def test_set_precip_type(test_radar):
     test_radar.precip_type = "auto"
-    assert test_radar.precip_type == "auto"
+    assert test_radar.precip_type[0] == "auto"
 
     if date.today().month in range(4, 11):
-        assert test_radar.layer_key == "rain"
+        assert test_radar.precip_type[1] == "rain"
     else:
-        assert test_radar.layer_key == "snow"
+        assert test_radar.precip_type[1] == "snow"


### PR DESCRIPTION
I started on this path looking for the memory leak and ended up with greatly improved speed. I think the major speed improvement comes from caching the composed radar images instead of composing them each time a GIF is needed.

In my tests it takes about half the time to create a GIF now.

As I said I started on this path after spending close to a day looking for the memory leak, which I'm convinced exists and mostly convinced that the leak is inside of the Pillow library. Here is one of the tests I've been using to find the memory leak:

```
import asyncio
import os
import psutil
from datetime import datetime

from env_canada import ECRadar


pid = os.getpid()
process = psutil.Process(pid)

radar_coords = ECRadar(coordinates=(45.41117000, -75.69812000))
radar_coords.precip_type = "auto"
while 1:
    animated_gif = asyncio.run(radar_coords.get_loop())
    print(
        f"{datetime.now().strftime("%H:%M:%S.%f")} {process.memory_info().rss / 1000000} MB"
    )
```

Since composed images are cached every call to `get_loop()` after the first call (which is building up the cache) basically just builds the GIF from the set of cached images, so I'm guessing the leak is in the Pillow GIF building code.