### PR TITLE
Fix TypeEror while logging in an exception

### DIFF
--- a/env_canada/ec_radar.py
+++ b/env_canada/ec_radar.py
@@ -195,7 +195,7 @@ class ECRadar(object):
                 return Cache.add("basemap", base_bytes, timedelta(days=7))
 
             except ClientConnectorError as e:
-                logging.warning("Map from %s could not be retrieved: %s" % map_url, e)
+                logging.warning("Map from %s could not be retrieved: %s",  map_url, e)
 
     async def _get_legend(self):
         """Fetch legend image."""


### PR DESCRIPTION
It would generate the following trace in Home Assistant:

```
2024-09-02 09:53:14.654 ERROR (MainThread) [homeassistant.components.environment_canada.coordinator] Unexpected error fetching environment_canada radar data
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/aiohttp/resolver.py", line 104, in resolve
    resp = await self._resolver.getaddrinfo(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
aiodns.error.DNSError: (1, 'DNS server returned answer with no data')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 1301, in _create_direct_connection
    hosts = await self._resolve_host(host, port, traces=traces)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 911, in _resolve_host
    return await asyncio.shield(resolved_host_task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 948, in _resolve_host_with_throttle
    addrs = await self._resolver.resolve(host, port, family=self._family)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/resolver.py", line 113, in resolve
    raise OSError(msg) from exc
OSError: DNS server returned answer with no data

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/env_canada/ec_radar.py", line 194, in _get_basemap
    base_bytes = await _get_resource(map_url, basemap_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/env_canada/ec_radar.py", line 109, in _get_resource
    response = await session.get(
               ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/client.py", line 657, in _request
    conn = await self._connector.connect(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 564, in connect
    proto = await self._create_connection(req, traces, timeout)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 975, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/connector.py", line 1307, in _create_direct_connection
    raise ClientConnectorError(req.connection_key, exc) from exc
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host maps.geogratis.gc.ca:443 ssl:default [None]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 354, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/environment_canada/coordinator.py", line 29, in _async_update_data
    await self.ec_data.update()
  File "/usr/local/lib/python3.12/site-packages/env_canada/ec_radar.py", line 337, in update
    self.image = await self.get_loop()
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/env_canada/ec_radar.py", line 359, in get_loop
    await self._get_basemap()
  File "/usr/local/lib/python3.12/site-packages/env_canada/ec_radar.py", line 198, in _get_basemap
    logging.warning("Map from %s could not be retrieved: %s" % map_url, e)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
TypeError: not enough arguments for format string
```