### PR TITLE
Removes errors flagged by pyright and ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ci:
   autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit.com hooks
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
 
-        for more information, see https://pre-commit.ci
+    for more information, see https://pre-commit.ci
   autofix_prs: true
-  autoupdate_branch: ''
-  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
   skip: []
   submodules: false
@@ -28,15 +28,6 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer # ensure that file is either empty, or ends with one newline
       - id: trailing-whitespace
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.21
     hooks:
@@ -53,20 +44,23 @@ repos:
           - types-python-dateutil
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.6
+    rev: v0.9.6
     hooks:
-    # Run the linter.
-    - id: ruff
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format
+        args: [--no-fix]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:
-    - id: pyupgrade
+      - id: pyupgrade
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-    - id: python-use-type-annotations
-    - id: python-check-blanket-noqa
-    - id: python-check-blanket-type-ignore
-    - id: python-check-mock-methods
-    - id: python-no-eval
-    - id: python-no-log-warn
+      - id: python-use-type-annotations
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-check-mock-methods
+      - id: python-no-eval
+      - id: python-no-log-warn

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: ruff
       # Run the formatter.
       - id: ruff-format
-        args: [--no-fix]
+        args: [--check]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:


### PR DESCRIPTION
Changes:
- Removed errors in ec_weather.py:
    - Most errors were of the form `weather_tree.find("<something>).text`. Error because find can return None, so effectively doing a `None.text`.
    -  Building ec_weather `self.metadata` simplified. After refactoring to remove error meant it was simpler to just remove `metadata_meta`.
- pre-commit: removed isort and black. ruff can handle both of those and there was a conflict with black sorting one way and ruff another (this was the trigger to include this change in this PR). More can be done to update pre-commit, but it is functional enough at the moment.