### PR TITLE
feature(update)!: Add resilience to error handling, including returning cached data

### DIFF
--- a/env_canada/__init__.py
+++ b/env_canada/__init__.py
@@ -5,10 +5,11 @@ __all__ = [
     "ECHydro",
     "ECRadar",
     "ECWeather",
+    "ECWeatherUpdateFailed",
 ]
 
 from .ec_aqhi import ECAirQuality
 from .ec_historical import ECHistorical, ECHistoricalRange
 from .ec_hydro import ECHydro
 from .ec_radar import ECRadar
-from .ec_weather import ECWeather
+from .ec_weather import ECWeather, ECWeatherUpdateFailed

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -460,7 +460,7 @@ class ECWeather:
             title = alert.attrib.get("description")
             type_ = alert.attrib.get("type")
             if title is not None and type_ is not None and type_ in ALERT_TYPE_TO_NAME:
-                self.alerts[ALERT_TYPE_TO_NAME[type_]]["value"].append(  # type: ignore
+                self.alerts[ALERT_TYPE_TO_NAME[type_]]["value"].append(  # type: ignore[attr-defined]
                     {
                         "title": title.strip().title(),
                         "date": _get_xml_text(alert, "./dateTime[last()]/textSummary"),

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import re
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import voluptuous as vol
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout
@@ -267,7 +268,7 @@ def closest_site(site_list, lat, lon):
 class ECWeather:
     """Get weather data from Environment Canada."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: dict[str, Any]) -> None:
         """Initialize the data object."""
 
         init_schema = vol.Schema(

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -268,7 +268,7 @@ def closest_site(site_list, lat, lon):
 class ECWeather:
     """Get weather data from Environment Canada."""
 
-    def __init__(self, **kwargs: dict[str, Any]) -> None:
+    def __init__(self, **kwargs):
         """Initialize the data object."""
 
         init_schema = vol.Schema(

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -33,7 +33,7 @@ __all__ = ["ECWeather", "ECWeatherUpdateFailed"]
 @dataclass
 class MetaData:
     attribution: str
-    timestamp: datetime = datetime(1970, 1, 1, 0, 0)
+    timestamp: datetime = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
     station: str | None = None
     location: str | None = None
     cache_returned_on_update: int = 0  # Resets to 0 after successful update
@@ -378,7 +378,6 @@ class ECWeather:
                     timeout=CLIENT_TIMEOUT,
                 )
                 weather_xml = await response.text()
-                self.station_id = ""
         except ClientResponseError as err:
             self.handle_error(
                 err,

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -4,7 +4,12 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import voluptuous as vol
-from aiohttp import ClientResponseError, ClientSession, ClientTimeout
+from aiohttp import (
+    ClientConnectorDNSError,
+    ClientResponseError,
+    ClientSession,
+    ClientTimeout,
+)
 from dateutil import parser, tz
 from geopy import distance
 from lxml import etree as et
@@ -378,6 +383,9 @@ class ECWeather:
                     timeout=CLIENT_TIMEOUT,
                 )
                 weather_xml = await response.text()
+        except (ClientConnectorDNSError, TimeoutError) as err:
+            self.handle_error(err, f"Unable to retrieve weather: {err}")
+            return
         except ClientResponseError as err:
             self.handle_error(
                 err,

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -2,7 +2,6 @@ import csv
 import logging
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 import voluptuous as vol
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout
@@ -461,7 +460,7 @@ class ECWeather:
             title = alert.attrib.get("description")
             type_ = alert.attrib.get("type")
             if title is not None and type_ is not None and type_ in ALERT_TYPE_TO_NAME:
-                self.alerts[ALERT_TYPE_TO_NAME[type_]]["value"].append(
+                self.alerts[ALERT_TYPE_TO_NAME[type_]]["value"].append(  # type: ignore
                     {
                         "title": title.strip().title(),
                         "date": _get_xml_text(alert, "./dateTime[last()]/textSummary"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "env_canada"
 description="A package to access meteorological data from Environment Canada"
-version="0.8.0"
+version="0.8.1"
 authors = [
   {name = "Michael Davie", email = "michael.davie@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "env_canada"
 description="A package to access meteorological data from Environment Canada"
-version="0.8.1"
+version="0.9.0"
 authors = [
   {name = "Michael Davie", email = "michael.davie@gmail.com"},
 ]

--- a/tests/__snapshots__/ec_weather_test.ambr
+++ b/tests/__snapshots__/ec_weather_test.ambr
@@ -32,6 +32,7 @@
         ]),
       }),
     }),
+    cache_returned=0,
     conditions=dict({
       'condition': dict({
         'label': 'Condition',
@@ -472,6 +473,7 @@
       }),
     ]),
     language='english',
+    last_successful_update=FakeDatetime(2025, 2, 6, 0, 0, tzinfo=datetime.timezone.utc),
     lat=45.33,
     lon=-75.58,
     max_data_age=2,

--- a/tests/__snapshots__/ec_weather_test.ambr
+++ b/tests/__snapshots__/ec_weather_test.ambr
@@ -473,7 +473,6 @@
       }),
     ]),
     language='english',
-    last_successful_update=FakeDatetime(2025, 2, 6, 0, 0, tzinfo=datetime.timezone.utc),
     lat=45.33,
     lon=-75.58,
     max_data_age=2,

--- a/tests/__snapshots__/ec_weather_test.ambr
+++ b/tests/__snapshots__/ec_weather_test.ambr
@@ -32,7 +32,6 @@
         ]),
       }),
     }),
-    cache_returned=0,
     conditions=dict({
       'condition': dict({
         'label': 'Condition',
@@ -476,12 +475,7 @@
     lat=45.33,
     lon=-75.58,
     max_data_age=2,
-    metadata=dict({
-      'attribution': 'Data provided by Environment Canada',
-      'location': 'Ottawa (Kanata - Orléans)',
-      'station': "Ottawa Macdonald-Cartier Int'l Airport",
-      'timestamp': FakeDatetime(2025, 2, 5, 23, 8, 27, tzinfo=tzutc()),
-    }),
+    metadata=MetaData(attribution='Data provided by Environment Canada', timestamp=FakeDatetime(2025, 2, 5, 23, 8, 27, tzinfo=tzutc()), station="Ottawa Macdonald-Cartier Int'l Airport", location='Ottawa (Kanata - Orléans)', cache_returned_on_update=0, last_update_error=''),
     site_list=list([
       dict({
         'Codes': 's0000001',

--- a/tests/ec_radar_test.py
+++ b/tests/ec_radar_test.py
@@ -87,6 +87,6 @@ async def test_get_radar_image_with_mock_data(snapshot: SnapshotAssertion):
         await tr.update()
 
         # Should catch if something happens with number of radar frames retrieved
-        assert mock.call_count == 34
+        assert mock.call_count == 3
 
     assert test_radar == snapshot


### PR DESCRIPTION
Environment Canada hiccups every now and again and either does not respond to a request or returns a 404. Certainly there have been instances of the service being down temporarily which accounts for the lack of response. The 404 we can only guess is because the site is being updated at the point when we try to get the weather data.

No matter the cause, if there is an error then we will return cached data for up to the configured `max_age` time (default, 2 hours; HA does not change the default).

Breaking changes:
All exceptions raised in `update()` are now `ECWeatherUpdateFailed`. An `update()` would previous return `ClientSessionError` or `ECWeatherUpdateFailed` depending on the situation.

The `metadata` has been changed to a `dataclass` from a `dict`. This was done for better typing and more clarity on the fields that are allowing in the `metadata`. New fields in the `metadata` are for indicating when cached data was returned and what the update error was.