### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,14 +29,14 @@ repos:
       - id: end-of-file-fixer # ensure that file is either empty, or ends with one newline
       - id: trailing-whitespace
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.21
+    rev: 0.7.22
     hooks:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-black
+          - mdformat-ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.16.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -44,7 +44,7 @@ repos:
           - types-python-dateutil
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.6
+    rev: v0.11.13
     hooks:
       # Run the linter.
       - id: ruff


### PR DESCRIPTION
## Summary

Updates pre-commit hook versions to their latest releases for improved tooling and bug fixes.

## Changes

- **mdformat**: `0.7.21` → `0.7.22`
- **mypy**: `v1.14.1` → `v1.16.0` 
- **ruff-pre-commit**: `v0.9.6` → `v0.11.13`
- **mdformat dependency**: Switch from `mdformat-black` to `mdformat-ruff` for consistency with the project's use of ruff

## Benefits

- Latest bug fixes and improvements in all tools
- Better type checking with mypy 1.16.0
- Enhanced linting and formatting with ruff 0.11.13
- Consistent use of ruff for both code and markdown formatting

## Testing

✅ All pre-commit hooks tested and passing
✅ No conflicts with existing codebase
✅ Hooks install and run successfully

This replaces the obsolete PR #107 which contained changes that are no longer relevant after the ECMap implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)