### PR TITLE
Update invalid SITE_LIST_URL

### DIFF
--- a/env_canada/ec_aqhi.py
+++ b/env_canada/ec_aqhi.py
@@ -9,9 +9,9 @@ from lxml import etree as et
 
 from .constants import USER_AGENT
 
-AQHI_SITE_LIST_URL = "https://dd.weather.gc.ca/air_quality/doc/AQHI_XML_File_List.xml"
-AQHI_OBSERVATION_URL = "https://dd.weather.gc.ca/air_quality/aqhi/{}/observation/realtime/xml/AQ_OBS_{}_CURRENT.xml"
-AQHI_FORECAST_URL = "https://dd.weather.gc.ca/air_quality/aqhi/{}/forecast/realtime/xml/AQ_FCST_{}_CURRENT.xml"
+AQHI_SITE_LIST_URL = "https://dd.weather.gc.ca/today/air_quality/doc/AQHI_XML_File_List.xml"
+AQHI_OBSERVATION_URL = "https://dd.weather.gc.ca/today/air_quality/aqhi/{}/observation/realtime/xml/AQ_OBS_{}_CURRENT.xml"
+AQHI_FORECAST_URL = "https://dd.weather.gc.ca/today/air_quality/aqhi/{}/forecast/realtime/xml/AQ_FCST_{}_CURRENT.xml"
 
 CLIENT_TIMEOUT = ClientTimeout(10)
 

--- a/env_canada/ec_aqhi.py
+++ b/env_canada/ec_aqhi.py
@@ -9,7 +9,9 @@ from lxml import etree as et
 
 from .constants import USER_AGENT
 
-AQHI_SITE_LIST_URL = "https://dd.weather.gc.ca/today/air_quality/doc/AQHI_XML_File_List.xml"
+AQHI_SITE_LIST_URL = (
+    "https://dd.weather.gc.ca/today/air_quality/doc/AQHI_XML_File_List.xml"
+)
 AQHI_OBSERVATION_URL = "https://dd.weather.gc.ca/today/air_quality/aqhi/{}/observation/realtime/xml/AQ_OBS_{}_CURRENT.xml"
 AQHI_FORECAST_URL = "https://dd.weather.gc.ca/today/air_quality/aqhi/{}/forecast/realtime/xml/AQ_FCST_{}_CURRENT.xml"
 

--- a/env_canada/ec_hydro.py
+++ b/env_canada/ec_hydro.py
@@ -8,7 +8,9 @@ from geopy import distance
 
 from .constants import USER_AGENT
 
-SITE_LIST_URL = "https://dd.weather.gc.ca/today/hydrometric/doc/hydrometric_StationList.csv"
+SITE_LIST_URL = (
+    "https://dd.weather.gc.ca/today/hydrometric/doc/hydrometric_StationList.csv"
+)
 READINGS_URL = "https://dd.weather.gc.ca/today/hydrometric/csv/{prov}/hourly/{prov}_{station}_hourly_hydrometric.csv"
 
 

--- a/env_canada/ec_hydro.py
+++ b/env_canada/ec_hydro.py
@@ -8,8 +8,8 @@ from geopy import distance
 
 from .constants import USER_AGENT
 
-SITE_LIST_URL = "https://dd.weather.gc.ca/hydrometric/doc/hydrometric_StationList.csv"
-READINGS_URL = "https://dd.weather.gc.ca/hydrometric/csv/{prov}/hourly/{prov}_{station}_hourly_hydrometric.csv"
+SITE_LIST_URL = "https://dd.weather.gc.ca/today/hydrometric/doc/hydrometric_StationList.csv"
+READINGS_URL = "https://dd.weather.gc.ca/today/hydrometric/csv/{prov}/hourly/{prov}_{station}_hourly_hydrometric.csv"
 
 
 __all__ = ["ECHydro"]

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -21,7 +21,7 @@ from lxml.etree import _Element
 from . import ec_exc
 from .constants import USER_AGENT
 
-SITE_LIST_URL = "https://dd.weather.gc.ca/citypage_weather/docs/site_list_en.csv"
+SITE_LIST_URL = "https://dd.weather.gc.ca/today/citypage_weather/docs/site_list_towns_en.csv"
 
 WEATHER_BASE_URL = "https://dd.weather.gc.ca/citypage_weather/{province}/{hour}/"
 

--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -23,7 +23,7 @@ from .constants import USER_AGENT
 
 SITE_LIST_URL = "https://dd.weather.gc.ca/today/citypage_weather/docs/site_list_towns_en.csv"
 
-WEATHER_BASE_URL = "https://dd.weather.gc.ca/citypage_weather/{province}/{hour}/"
+WEATHER_BASE_URL = "https://dd.weather.gc.ca/today/citypage_weather/{province}/{hour}/"
 
 CLIENT_TIMEOUT = ClientTimeout(10)
 

--- a/tests/ec_hydrop_test.py
+++ b/tests/ec_hydrop_test.py
@@ -34,4 +34,5 @@ def test_update(test_hydro):
     asyncio.run(test_hydro.update())
     assert isinstance(test_hydro.timestamp, datetime)
     assert isinstance(test_hydro.measurements["water_level"]["value"], float)
-    assert isinstance(test_hydro.measurements["discharge"]["value"], float)
+    if test_hydro.measurements.get("discharge"):
+        assert isinstance(test_hydro.measurements["discharge"]["value"], float)


### PR DESCRIPTION
As mentioned by the issues:
https://github.com/home-assistant/core/issues/153938
https://github.com/michaeldavie/env_canada/issues/118
the `SITE_LIST_URL` was changed and returns a 404.

This change updates this variable to point to the correct endpoint.