### PR TITLE
Fix crash when forecast period or summary is None

### DIFF
--- a/env_canada/ec_weather.py
+++ b/env_canada/ec_weather.py
@@ -605,7 +605,9 @@ class ECWeather:
 
             self.conditions["text_summary"] = {
                 "label": summary_meta["label"][self.language],
-                "value": ". ".join([period, summary]),
+                "value": ". ".join(
+                    part for part in [period, summary] if part is not None
+                ),
             }
 
         # Update alerts


### PR DESCRIPTION
## Summary

- Fix `TypeError: sequence item 0: expected str instance, NoneType found` crash in `ec_weather.py` line 607
- When Environment Canada returns weather data without a `forecast_period` or `text_summary`, the `str.join()` call crashes because it tries to join `None` values
- Filter out `None` values before joining to handle missing data gracefully

## Reproduction

```python
from env_canada import ECWeather
import asyncio

async def test():
    w = ECWeather(station_id="AB/s0000126", language="english")
    await w.update()  # Crashes with TypeError

asyncio.run(test())
```

## Fix

```python
# Before (crashes when period or summary is None):
"value": ". ".join([period, summary]),

# After (filters out None values):
"value": ". ".join(
    part for part in [period, summary] if part is not None
),
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)