### PR TITLE
Historical data has changed from station id to climate id.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ ci:
   submodules: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: mixed-line-ending
       - id: name-tests-test
@@ -29,14 +29,14 @@ repos:
       - id: end-of-file-fixer # ensure that file is either empty, or ends with one newline
       - id: trailing-whitespace
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
           - mdformat-ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.16.0
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -44,15 +44,16 @@ repos:
           - types-python-dateutil
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.13
+    rev: v0.15.5
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
+        args:
+          - --fix
       # Run the formatter.
       - id: ruff-format
-        args: [--check]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -178,19 +178,14 @@ async def get_historical_stations(
         stations = {}
         for station_req_form in station_req_forms:
             station = {}
-            station_name = station_req_form.xpath(
+            station_table = station_req_form.xpath(
                 './/div[@class="col-md-10 col-sm-8 col-xs-8"]'
-            )[0].text
-            station["prov"] = station_req_form.xpath(
-                './/div[@class="col-md-10 col-sm-8 col-xs-8"]'
-            )[1].text
-            station["proximity"] = float(
-                station_req_form.xpath('.//div[@class="col-md-10 col-sm-8 col-xs-8"]')[
-                    2
-                ].text
             )
+            station_name = station_table[0].text
+            station["prov"] = station_table[1].text
+            station["proximity"] = float(station_table[2].text)
             station["id"] = station_req_form.find(
-                "input[@name='StationID']"
+                "input[@name='climate_id']"
             ).attrib.get("value")
             station["hlyRange"] = station_req_form.find(
                 "input[@name='hlyRange']"
@@ -219,6 +214,7 @@ class ECHistorical:
                     int, vol.Range(1840, datetime.today().year)
                 ),
                 vol.Required("month", default=1): vol.All(int, vol.Range(1, 12)),
+                vol.Required("day", default=1): vol.All(int, vol.Range(1, 31)),
                 vol.Required("language", default="english"): vol.In(
                     ["english", "french"]
                 ),
@@ -233,6 +229,7 @@ class ECHistorical:
         self.timeframe = kwargs["timeframe"]
         self.year = kwargs["year"]
         self.month = kwargs["month"]
+        self.day = kwargs["day"]
         self.language = kwargs["language"]
         self.format = kwargs["format"]
         self.submit = "Download+Data"
@@ -244,9 +241,10 @@ class ECHistorical:
         """Get the historical data from Environment Canada."""
 
         params = {
-            "stationID": self.station_id,
+            "climate_id": self.station_id,
             "Year": self.year,
             "Month": self.month,
+            "Day": self.day,
             "format": self.format,
             "timeframe": self.timeframe,
             "submit": self.submit,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "env_canada"
 description="A package to access meteorological data from Environment Canada"
-version="0.13.2"
+version="0.13.3"
 authors = [
   {name = "Michael Davie", email = "michael.davie@gmail.com"},
 ]

--- a/tests/ec_historical_test.py
+++ b/tests/ec_historical_test.py
@@ -9,19 +9,19 @@ from env_canada import ECHistorical, ECHistoricalRange
 @pytest.mark.parametrize(
     "init_parameters",
     [
-        {"station_id": 48370, "year": 2021},
-        {"station_id": 48370, "year": 2021, "language": "english"},
-        {"station_id": 48370, "year": 2021, "language": "french"},
-        {"station_id": 48370, "year": 2021, "format": "csv"},
-        {"station_id": 48370, "year": 2021, "format": "xml"},
+        {"station_id": 1096453, "year": 2021},
+        {"station_id": 1096453, "year": 2021, "language": "english"},
+        {"station_id": 1096453, "year": 2021, "language": "french"},
+        {"station_id": 1096453, "year": 2021, "format": "csv"},
+        {"station_id": 1096453, "year": 2021, "format": "xml"},
         {
-            "station_id": 48370,
+            "station_id": 1096453,
             "year": 2021,
             "month": 5,
             "format": "xml",
             "timeframe": 1,
         },
-        {"station_id": 48370, "year": 2021, "format": "csv", "timeframe": 1},
+        {"station_id": 1096453, "year": 2021, "format": "csv", "timeframe": 1},
     ],
 )
 def test_echistorical(init_parameters):
@@ -31,7 +31,7 @@ def test_echistorical(init_parameters):
 
 @pytest.fixture()
 def test_historical():
-    return ECHistorical(station_id=48370, year=2021)
+    return ECHistorical(station_id=1096453, year=2021)
 
 
 def test_update(test_historical):
@@ -43,10 +43,10 @@ def test_update(test_historical):
 @pytest.mark.parametrize(
     "station_id,timeframe,startdate,enddate",
     [
-        (10761, "daily", datetime(2022, 1, 1), datetime(2022, 12, 31)),
-        (10761, "daily", datetime(2022, 1, 1), datetime(2023, 12, 31)),
-        (10761, "daily", datetime(2022, 1, 1), datetime(2022, 11, 30)),
-        (10761, "hourly", datetime(2022, 1, 1), datetime(2022, 2, 3, 23, 59, 59)),
+        (1096453, "daily", datetime(2022, 1, 1), datetime(2022, 12, 31)),
+        (1096453, "daily", datetime(2022, 1, 1), datetime(2023, 12, 31)),
+        (1096453, "daily", datetime(2022, 1, 1), datetime(2022, 11, 30)),
+        (1096453, "hourly", datetime(2022, 1, 1), datetime(2022, 2, 3, 23, 59, 59)),
     ],
 )
 def test_historical_number_values(station_id, timeframe, startdate, enddate):


### PR DESCRIPTION
The tests are failing for the historical data pull. When I investigated it was due to a move from StationId in the form to climate_id. They also made the "Day" parameter required in the query parameter to download the data.

This pull request would address that change. by extracting the climate_id as the station id, adding a day attribute to the ECHistorical model with a default of 1 and including the day as a query parameter on the download.