### PR TITLE
Add support for alphanumeric climate ids

### DIFF
--- a/env_canada/ec_historical.py
+++ b/env_canada/ec_historical.py
@@ -124,6 +124,15 @@ def parse_timestamp(t):
     return parser.parse(t).replace(tzinfo=tz.UTC)
 
 
+def coerce_station_id(v):
+    """Coerce station_id to string, accepting both int and str inputs."""
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, str):
+        return v
+    raise vol.Invalid("station_id must be a string or integer")
+
+
 async def get_historical_stations(
     coordinates,
     radius=25,
@@ -209,7 +218,7 @@ class ECHistorical:
 
         init_schema = vol.Schema(
             {
-                vol.Required("station_id"): int,
+                vol.Required("station_id"): vol.All(coerce_station_id),
                 vol.Required("year"): vol.All(
                     int, vol.Range(1840, datetime.today().year)
                 ),
@@ -368,7 +377,7 @@ class ECHistoricalRange:
             stations = pd.DataFrame(asyncio.run(get_historical_stations(coordinates, start_year=2022,
                                                             end_year=2022, radius=200, limit=100))).T
 
-            ec = ECHistoricalRange(station_id=int(stations.iloc[0,2]), timeframe="hourly",
+            ec = ECHistoricalRange(station_id=stations.iloc[0,2], timeframe="hourly",
                                     daterange=(datetime(2022, 7, 1, 12, 12), datetime(2022, 8, 1, 12, 12)))
 
             ec.get_data()
@@ -392,7 +401,7 @@ class ECHistoricalRange:
         """
         Return a DataFrame containing the data from the date range
         :param station_id: the ID of the station found with get_historical_stations
-        :type station_id: int
+        :type station_id: str or int
         :param daterange: the dates between which the data are retrieve
         :type daterange: tuple of datetime
         :param language: language in which the data are retrieved
@@ -403,7 +412,7 @@ class ECHistoricalRange:
 
         self.df = pd.DataFrame()
 
-        self.station_id = int(station_id)
+        self.station_id = str(station_id)
         self.startdate, self.stopdate = daterange
         self.months = self.monthlist(daterange=daterange)
         self.language = language

--- a/tests/ec_historical_test.py
+++ b/tests/ec_historical_test.py
@@ -10,6 +10,8 @@ from env_canada import ECHistorical, ECHistoricalRange
     "init_parameters",
     [
         {"station_id": 1096453, "year": 2021},
+        {"station_id": "1096453", "year": 2021},
+        {"station_id": "10476F0", "year": 2021},
         {"station_id": 1096453, "year": 2021, "language": "english"},
         {"station_id": 1096453, "year": 2021, "language": "french"},
         {"station_id": 1096453, "year": 2021, "format": "csv"},
@@ -44,6 +46,8 @@ def test_update(test_historical):
     "station_id,timeframe,startdate,enddate",
     [
         (1096453, "daily", datetime(2022, 1, 1), datetime(2022, 12, 31)),
+        ("1096453", "daily", datetime(2022, 1, 1), datetime(2022, 12, 31)),
+        ("10476F0", "daily", datetime(2022, 1, 1), datetime(2022, 12, 31)),
         (1096453, "daily", datetime(2022, 1, 1), datetime(2023, 12, 31)),
         (1096453, "daily", datetime(2022, 1, 1), datetime(2022, 11, 30)),
         (1096453, "hourly", datetime(2022, 1, 1), datetime(2022, 2, 3, 23, 59, 59)),


### PR DESCRIPTION
Follow on of #131, this PR updates `ECHistorical`  to support both integer and string climate ids. Turns out not all climate ids are integers. [Squamish Airport](https://climate.weather.gc.ca/climate_data/hourly_data_e.html?hlyRange=1982-05-17%7C2026-04-02&dlyRange=1982-05-01%7C2026-04-02&mlyRange=1982-01-01%7C2007-02-01&climate_id=10476F0&Prov=BC&urlExtension=_e.html&searchType=stnProx&optLimit=specDate&Month=3&Day=24&StartYear=1840&EndYear=2023&Year=2023&selRowPerPage=25&Line=27&txtRadius=200&optProxType=city&selCity=49%7C17%7C123%7C8%7CVancouver&selPark=&txtCentralLatDeg=&txtCentralLatMin=0&txtCentralLatSec=0&txtCentralLongDeg=&txtCentralLongMin=0&txtCentralLongSec=0&txtLatDecDeg=&txtLongDecDeg=&timeframe=1), for example, has a climate id of `10476F0`, which currently causes the following error when passed in:

```python
    ECHistorical(
  File "/home/justinlam/Documents/weathercan/.venv/lib/python3.11/site-packages/env_canada/ec_historical.py", line 226, in __init__
    kwargs = init_schema(kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/home/justinlam/Documents/weathercan/.venv/lib/python3.11/site-packages/voluptuous/schema_builder.py", line 205, in __call__
    return self._compiled([], data)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinlam/Documents/weathercan/.venv/lib/python3.11/site-packages/voluptuous/schema_builder.py", line 574, in validate_dict
    return base_validate(path, data.items(), out)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinlam/Documents/weathercan/.venv/lib/python3.11/site-packages/voluptuous/schema_builder.py", line 407, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: expected int for dictionary value @ data['station_id']
```

Squamish airport weather station, for reference:
<img width="1212" height="365" alt="image" src="https://github.com/user-attachments/assets/6ce251c1-0b1b-492b-b122-0358996d8e6b" />
