### PR TITLE
Fix math domain error / unclamped latitude in bounding box calc

### DIFF
--- a/env_canada/ec_map.py
+++ b/env_canada/ec_map.py
@@ -85,13 +85,20 @@ def _compute_bounding_box(distance, latittude, longitude):
     distance_from_point_km = distance
     angular_distance = distance_from_point_km / 6371.01
 
-    lat_min = latittude - angular_distance
-    lat_max = latittude + angular_distance
+    lat_min = max(-math.pi / 2, latittude - angular_distance)
+    lat_max = min(math.pi / 2, latittude + angular_distance)
 
-    delta_longitude = math.asin(math.sin(angular_distance) / math.cos(latittude))
+    cos_latittude = math.cos(latittude)
+    ratio = math.sin(angular_distance) / cos_latittude if cos_latittude else math.inf
 
-    lon_min = longitude - delta_longitude
-    lon_max = longitude + delta_longitude
+    if abs(ratio) >= 1:
+        # Circle encloses a pole: longitude spans the full range.
+        lon_min = -math.pi
+        lon_max = math.pi
+    else:
+        delta_longitude = math.asin(ratio)
+        lon_min = longitude - delta_longitude
+        lon_max = longitude + delta_longitude
     lon_min = round(math.degrees(lon_min), 5)
     lat_max = round(math.degrees(lat_max), 5)
     lon_max = round(math.degrees(lon_max), 5)

--- a/tests/ec_map_test.py
+++ b/tests/ec_map_test.py
@@ -132,14 +132,28 @@ class TestECMapInitialization:
         assert map_obj.fps == 10
         assert map_obj.loop_minutes == 30
 
-    def test_bounding_box_math_errors(self):
-        """Test coordinates that cause math domain errors in bounding box computation"""
-        # These coordinates are valid per schema but cause math errors in bounding box calc
-        # Should raise ValueError, not voluptuous error
-        with pytest.raises(ValueError):
-            ECMap(
-                coordinates=(90, -100), layer="rain"
-            )  # cos(90°) = 0, causes division by zero
+    def test_bounding_box_pole_enclosing(self):
+        """Coordinates/radius that enclose a pole should not raise, and should
+        span the full longitude range with latitude clamped to +/-90"""
+        map_obj = ECMap(coordinates=(90, -100), layer="rain")  # cos(90°) = 0
+        _, lon_min, lat_max, lon_max = map_obj.bbox
+        assert lat_max == 90.0
+        assert lon_min == -180.0
+        assert lon_max == 180.0
+
+        # From issue #141: circle radius large enough to enclose the pole
+        map_obj = ECMap(coordinates=(82.5, -62.3), radius=1000, layer="rain")
+        _, lon_min, lat_max, lon_max = map_obj.bbox
+        assert lat_max == 90.0
+        assert lon_min == -180.0
+        assert lon_max == 180.0
+
+    def test_bounding_box_latitude_clamped(self):
+        """Latitude should never exceed +/-90 even with a large radius near a pole"""
+        map_obj = ECMap(coordinates=(80, 0), radius=2000, layer="rain")
+        lat_min, _, lat_max, _ = map_obj.bbox
+        assert lat_max == 90.0
+        assert lat_min >= -90.0
 
     def test_edge_case_coordinates(self):
         """Test edge case coordinates that work with bounding box computation"""


### PR DESCRIPTION
## Summary
- `_compute_bounding_box()` (env_canada/ec_map.py) called `math.asin()` on `sin(angular_distance) / cos(latitude)`, which can exceed 1 whenever the requested circle encloses a pole (large `radius` and/or high latitude), raising `ValueError: math domain error`. This is reachable from `ECMap.__init__` with public API inputs (e.g. `ECMap(coordinates=(82.5, -62.3), radius=1000)`).
- `lat_min`/`lat_max` were also unclamped, so the same pole-enclosing scenario could produce latitudes outside +/-90.
- Now: when the ratio would put the circle over a pole, longitude spans the full -180..180 range instead of raising, and latitude is clamped to +/-90.

Fixes #141

## Test plan
- [x] Added regression tests reproducing the exact repro cases from #141 (`(82.5, -62.3)`/1000km, `(80, 0)`/2000km) confirming no exception and correct clamped/full-range bbox
- [x] Updated the old test that asserted `ValueError` for `(90, -100)` to assert the new graceful (non-crashing) behavior instead
- [x] `uv run pytest tests` — all pass
- [x] `uv run ruff check` / `uv run ruff format --check` — pass